### PR TITLE
io: fix stdin,stdout hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Not another JSON parser!_
 
 Marshals golang [AST](https://pkg.go.dev/go/ast) into JSON and unmarshals it back from JSON.
 
-It allows building pattern matching, statistical analysis, language transformation, search/data-mine/anything algorithms 
+It allows building pattern matching, statistical analysis, language transformation, search/data-mine/anything algorithms
 for golang with any other language (I like to do it with python. Check out [asty-python](https://github.com/asty-org/asty-python))
 
 ## Example
@@ -22,6 +22,7 @@ for golang with any other language (I like to do it with python. Check out [asty
 [Try it!](https://asty-org.github.io/)
 
 Input golang source
+
 ```golang
 package main
 
@@ -33,6 +34,7 @@ func main() {
 ```
 
 Ouput AST in JSON
+
 ```json
 {
   "NodeType": "File",
@@ -106,6 +108,16 @@ Ouput AST in JSON
 }
 ```
 
+## Install
+
+Install `asty` under `$GOPATH/bin`
+
+```bash
+go install github.com/asty-org/asty
+
+asty -h
+```
+
 ## Building
 
 Just `make`
@@ -114,11 +126,13 @@ If you want to do it differently use `go build`
 ## Usage
 
 Convert AST to JSON
+
 ```bash
 asty go2json -input <input.go> -output <output.json>
 ```
 
 Convert JSON to AST
+
 ```bash
 asty json2go -input <input.json> -output <output.go>
 ```
@@ -133,19 +147,19 @@ docker run astyorg/asty go2json -input <input.go> -output <output.json>
 
 ## Development principles
 
-- Make json output as close to real golang structures as possible. There is no additional logic introduced. 
-No normalization. No reinterpretation. The only things that were introduced are the names of some enum values.
-- Make it very explicit. No reflection. No listing of fields. This is done to facilitate future maintenance. 
-If something will be changed in future versions of golang this code will probably break compile-time.
-- Keep polymorphism in JSON structure. If some field references _expression_ then particular type will be 
-discriminated from object type name stored in separate field.
+- Make json output as close to real golang structures as possible. There is no additional logic introduced.
+  No normalization. No reinterpretation. The only things that were introduced are the names of some enum values.
+- Make it very explicit. No reflection. No listing of fields. This is done to facilitate future maintenance.
+  If something will be changed in future versions of golang this code will probably break compile-time.
+- Keep polymorphism in JSON structure. If some field references _expression_ then particular type will be
+  discriminated from object type name stored in separate field.
 
 ## Other solutions
 
-- https://github.com/ReconfigureIO/goblin reinterpret some structures (trying to simplify). 
-Out of maintenance for a long time. Still works in some forks.
+- https://github.com/ReconfigureIO/goblin reinterpret some structures (trying to simplify).
+  Out of maintenance for a long time. Still works in some forks.
 - https://github.com/CreativeInquiry/go2json tries to parse golang code with parser written in javascript.
-Also lacks maintenance. Developed for particular use case of HaXe traspiler.
+  Also lacks maintenance. Developed for particular use case of HaXe traspiler.
 
 ## Article
 

--- a/asty/io.go
+++ b/asty/io.go
@@ -1,0 +1,36 @@
+package asty
+
+import (
+	"io"
+	"os"
+)
+
+func noOpClose() error {
+	return nil
+}
+
+func OpenRead(input string) (reader io.Reader, close func() error, err error) {
+	if input == "" || input == "-" {
+		return os.Stdin, noOpClose, nil
+	}
+	f, err := os.Open(input)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() error {
+		return f.Close()
+	}, nil
+}
+
+func OpenOrCreateWrite(output string) (writer io.Writer, close func() error, err error) {
+	if output == "" {
+		return os.Stdout, noOpClose, nil
+	}
+	f, err := os.Create(output)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() error {
+		return f.Close()
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/asty-org/asty/asty"
 	"os"
 	"strings"
+
+	"github.com/asty-org/asty/asty"
 )
 
 const UsageString = `Usage: asty <command> [flags]
@@ -50,14 +51,6 @@ func main() {
 	err := fs.Parse(args[2:])
 	if err != nil {
 		printError(err)
-	}
-
-	if input == "" {
-		input = os.Stdin.Name()
-	}
-
-	if output == "" {
-		output = os.Stdout.Name()
 	}
 
 	options := asty.Options{


### PR DESCRIPTION
When running on MacOS, the following command fails:
```bash
asty go2json -input some.go
```
The message is about having no permission to write to `/dev/stdout`.

To fix that, simply don't rely on stdout's name. Specifically, don't call `os.Create` on it